### PR TITLE
Fix decimal serialization and JSON dynamic field decoding

### DIFF
--- a/ballerina/tests/test.bal
+++ b/ballerina/tests/test.bal
@@ -130,3 +130,142 @@ function testQueryVectors() returns error? {
         test:assertEquals(result[0][0]["content"], "test");
     }
 }
+
+// Regression coverage for the dynamic-field JSON pipeline.
+//
+// Write side: a Ballerina `decimal` (BDecimal) used to slip past `convertToJsonFields`
+// and reach Gson, which reflectively dumped its internal `DecimalValue` fields as
+// `{"valueKind":"OTHER","value":...}` instead of a JSON number. Once the row was
+// persisted that way the value could never be read back as a number.
+//
+// Read side: any non-list dynamic-field value used to be `.toString()`'d into a
+// `BString`, even when Milvus returned a Gson `JsonElement`. That stringification
+// destroyed nested structure and collapsed every JSON number to a single textual
+// representation, forcing every caller to re-parse the string and lose the
+// decimal-vs-float distinction.
+//
+// This test exercises both halves end-to-end: it upserts a row whose dynamic
+// `metadata` property is a nested record carrying a decimal, an int, a float, a
+// boolean, a string, a json array, and a nested json object. It then queries the
+// row back and asserts each value comes back with the correct Ballerina type.
+string jsonMetadataCollection = "json_metadata_collection";
+int jsonMetadataId = 70001;
+
+@test:Config {
+    groups: ["json-metadata"]
+}
+function testCreateJsonMetadataCollection() returns error? {
+    check milvusClient->createCollection({
+        collectionName: jsonMetadataCollection,
+        dimension: 3,
+        primaryFieldName: "primary_key"
+    });
+}
+
+@test:Config {
+    groups: ["json-metadata"],
+    dependsOn: [testCreateJsonMetadataCollection]
+}
+function testUpsertJsonMetadataWithDecimal() returns error? {
+    record {} metadata = {
+        "fileName": "decimals.txt",
+        "fileSize": 16541d,
+        "ratio": 0.75d,
+        "index": 7,
+        "approved": true,
+        "tags": <json>["alpha", "beta"],
+        "nested": <json>{"source": "unit-test", "revision": 3}
+    };
+    check milvusClient->upsert({
+        collectionName: jsonMetadataCollection,
+        data: {
+            primaryKey: {
+                value: jsonMetadataId,
+                fieldName: "primary_key"
+            },
+            vectors: [0.7, 0.8, 0.9],
+            properties: {
+                "content": "decimals",
+                "type": "text",
+                "metadata": metadata
+            }
+        }
+    });
+    check milvusClient->createIndex({
+        collectionName: jsonMetadataCollection,
+        primaryKey: "primary_key",
+        fieldNames: ["vector"]
+    });
+}
+
+@test:Config {
+    groups: ["json-metadata"],
+    dependsOn: [testUpsertJsonMetadataWithDecimal]
+}
+function testQueryJsonMetadataPreservesTypes() returns error? {
+    check milvusClient->loadCollection(jsonMetadataCollection);
+    SearchResult[][] result = check milvusClient->search({
+        collectionName: jsonMetadataCollection,
+        vectors: [[0.7, 0.8, 0.9]],
+        topK: 1,
+        outputFields: ["content", "metadata"]
+    });
+    test:assertTrue(result.length() > 0 && result[0].length() > 0,
+        "expected the upserted row to be retrievable");
+
+    OutputFields? outputFields = result[0][0].outputFields;
+    if outputFields is () {
+        test:assertFail("expected outputFields to be returned");
+    }
+
+    anydata rawMetadata = outputFields["metadata"];
+    if rawMetadata !is map<anydata> {
+        test:assertFail("expected JSON dynamic column to be returned as a structured map, not a string");
+    }
+
+    test:assertEquals(rawMetadata["fileName"], "decimals.txt");
+    // JSON has one number type, so a whole-number `decimal` on the way in is
+    // indistinguishable from an `int` on the way out. The connector returns
+    // the most natural Ballerina type — int for whole numbers (when they fit
+    // in long), decimal for fractional. Callers that need the value pinned
+    // back to `decimal` should rely on a typed schema (e.g. `cloneWithType`).
+    test:assertEquals(rawMetadata["fileSize"], 16541);
+    // The crux of the fix: a fractional Ballerina decimal must round-trip as
+    // `decimal`, not collapse to `float` and not get reflected into a
+    // `{"valueKind":"OTHER",...}` blob on the write side.
+    test:assertEquals(rawMetadata["ratio"], 0.75d);
+    // Whole numbers should come back as int, not float, since they fit in long.
+    test:assertEquals(rawMetadata["index"], 7);
+    test:assertEquals(rawMetadata["approved"], true);
+    // Nested json structures must preserve their shape, not be flattened to a string.
+    test:assertEquals(rawMetadata["tags"], <json>["alpha", "beta"]);
+    anydata nested = rawMetadata["nested"];
+    test:assertTrue(nested is map<anydata>,
+        "expected nested object to be returned as a structured map");
+    if nested is map<anydata> {
+        test:assertEquals(nested["source"], "unit-test");
+        test:assertEquals(nested["revision"], 3);
+    }
+}
+
+@test:Config {
+    groups: ["json-metadata"],
+    dependsOn: [testQueryJsonMetadataPreservesTypes]
+}
+function testFilterOnJsonMetadataField() returns error? {
+    // The `metadata["fileName"]` filter syntax only works when the dynamic
+    // column is stored as a real JSON object — i.e. when the write path didn't
+    // collapse the record into a string. This guards against any future
+    // regression that puts metadata back through `toJsonString()` (or similar)
+    // on the Ballerina side.
+    SearchResult[][] result = check milvusClient->search({
+        collectionName: jsonMetadataCollection,
+        vectors: [[0.7, 0.8, 0.9]],
+        topK: 1,
+        filter: string `metadata["fileName"] == "decimals.txt"`,
+        outputFields: ["content"]
+    });
+    test:assertTrue(result.length() > 0 && result[0].length() > 0,
+        "expected metadata[\"fileName\"] filter to match the upserted row");
+    test:assertEquals(result[0][0].id, jsonMetadataId);
+}

--- a/native/src/main/java/io/ballerina/lib/milvus/Utils.java
+++ b/native/src/main/java/io/ballerina/lib/milvus/Utils.java
@@ -19,15 +19,20 @@
 package io.ballerina.lib.milvus;
 
 import com.google.gson.Gson;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
+import com.google.gson.JsonPrimitive;
 import io.ballerina.runtime.api.creators.ErrorCreator;
 import io.ballerina.runtime.api.creators.TypeCreator;
 import io.ballerina.runtime.api.creators.ValueCreator;
 import io.ballerina.runtime.api.types.ArrayType;
+import io.ballerina.runtime.api.types.PredefinedTypes;
 import io.ballerina.runtime.api.types.RecordType;
 import io.ballerina.runtime.api.types.TypeTags;
 import io.ballerina.runtime.api.utils.StringUtils;
 import io.ballerina.runtime.api.values.BArray;
+import io.ballerina.runtime.api.values.BDecimal;
 import io.ballerina.runtime.api.values.BError;
 import io.ballerina.runtime.api.values.BMap;
 import io.ballerina.runtime.api.values.BString;
@@ -38,6 +43,7 @@ import io.milvus.v2.service.vector.request.data.FloatVec;
 import io.milvus.v2.service.vector.response.QueryResp;
 import io.milvus.v2.service.vector.response.SearchResp;
 
+import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -79,6 +85,11 @@ public class Utils {
     private static Object convertToJsonFields(Object value) {
         if (value instanceof BString stringValue) {
             return stringValue.getValue();
+        }
+        if (value instanceof BDecimal decimalValue) {
+            // Without this, Gson reflects on the Ballerina DecimalValue object and emits
+            // {"valueKind":"OTHER","value":...} instead of a numeric literal.
+            return decimalValue.decimalValue();
         }
         if (value instanceof BArray arr) {
             List<Object> list = new ArrayList<>();
@@ -140,6 +151,13 @@ public class Utils {
         for (Map.Entry<String, Object> entry : entityEntries) {
             String key = entry.getKey();
             Object value = entry.getValue();
+            if (value instanceof JsonElement jsonElement) {
+                // JSON-typed dynamic columns come back as Gson JsonElement. Convert into a
+                // structured Ballerina value (preferring decimal for fractional numbers) so
+                // that callers don't lose type information through a string round-trip.
+                targetMap.put(StringUtils.fromString(key), convertJsonElement(jsonElement));
+                continue;
+            }
             if (!(value instanceof List<?> list)) {
                 targetMap.put(StringUtils.fromString(key),
                         StringUtils.fromString(value.toString()));
@@ -162,6 +180,50 @@ public class Utils {
                 targetMap.put(StringUtils.fromString(key), stringArray);
             }
         }
+    }
+
+    private static Object convertJsonElement(JsonElement element) {
+        if (element == null || element.isJsonNull()) {
+            return null;
+        }
+        if (element instanceof JsonPrimitive primitive) {
+            if (primitive.isBoolean()) {
+                return primitive.getAsBoolean();
+            }
+            if (primitive.isString()) {
+                return StringUtils.fromString(primitive.getAsString());
+            }
+            // primitive.isNumber()
+            BigDecimal bd = primitive.getAsBigDecimal();
+            // Whole numbers (no fractional part, fit in long) come back as Ballerina int;
+            // everything else as decimal so precision is preserved end-to-end.
+            if (bd.scale() <= 0 || bd.stripTrailingZeros().scale() <= 0) {
+                try {
+                    return bd.longValueExact();
+                } catch (ArithmeticException ignored) {
+                    // Falls through to decimal for values that don't fit a long.
+                }
+            }
+            return ValueCreator.createDecimalValue(bd);
+        }
+        if (element instanceof JsonArray array) {
+            BArray result = ValueCreator.createArrayValue(
+                    TypeCreator.createArrayType(PredefinedTypes.TYPE_JSON));
+            for (JsonElement child : array) {
+                result.append(convertJsonElement(child));
+            }
+            return result;
+        }
+        if (element instanceof JsonObject object) {
+            BMap<BString, Object> result = ValueCreator.createMapValue(
+                    TypeCreator.createMapType(PredefinedTypes.TYPE_JSON));
+            for (Map.Entry<String, JsonElement> field : object.entrySet()) {
+                result.put(StringUtils.fromString(field.getKey()), convertJsonElement(field.getValue()));
+            }
+            return result;
+        }
+        // Defensive fallback — should not happen with current Gson types.
+        return StringUtils.fromString(element.toString());
     }
 
     protected static List<BaseVector> getVectors(BArray vectors) {


### PR DESCRIPTION
## Purpose

Fixes https://github.com/wso2/product-integrator/issues/1100

Two related defects in the dynamic-field JSON pipeline (`native/src/main/java/io/ballerina/lib/milvus/Utils.java`) caused values flowing through Milvus' open `metadata` column to be corrupted on the way in and lossy on the way out. Both surfaced first as a downstream `ConversionError` in `ai:VectorKnowledgeBase.ingest` (issue #1100), but the root cause is in this connector — fixing it here removes a workaround that `ai.milvus` would otherwise have to carry.

## Issue analysis

### 1. Write side: `decimal` metadata is reflected to a `DecimalValue` blob

`convertToJsonFields` handed Ballerina `decimal` values straight to Gson. Gson has no `BDecimal` adapter, so it reflected on the runtime class and emitted:

```json
"fileSize": {"valueKind":"OTHER","value":...,"type":{...},"shapeCalculated":false}
```

instead of a numeric literal. Once a row was persisted that way the value could never round-trip back as a number — `cloneWithType(ai:Metadata)` on the read side would fail, which is exactly the failure surface seen in #1100 once the primary-key bug was past.

### 2. Read side: dynamic-field values get `.toString()`'d into a `BString`

When Milvus returned a JSON-typed dynamic column, the value arrived as a Gson `JsonElement`. The previous code only special-cased `List`, so any non-list element fell into:

```java
targetMap.put(StringUtils.fromString(key), StringUtils.fromString(value.toString()));
```

That collapsed nested objects, json arrays, and every numeric type to a single textual representation, forcing every caller to re-parse the string and losing the decimal-vs-float distinction permanently.

## Changes made

`native/src/main/java/io/ballerina/lib/milvus/Utils.java`:

- **Write path** — added a `BDecimal` branch in the value converter that returns `decimalValue.decimalValue()` (a `java.math.BigDecimal`), so Gson serializes it as a numeric literal instead of reflecting on the Ballerina runtime object.
- **Read path** — added `convertJsonElement(JsonElement)` and routed `JsonElement`-typed dynamic values through it before they are placed into the result map. The helper recursively reconstructs Ballerina values:
  - `JsonPrimitive` boolean → Ballerina `boolean`
  - `JsonPrimitive` string → `BString`
  - `JsonPrimitive` number → `int` for whole numbers that fit a `long`, otherwise `decimal` (preserves precision; matches Ballerina's natural numeric typing)
  - `JsonArray` → `BArray` of `json`
  - `JsonObject` → `BMap<BString, json>`
  - `JsonNull` → `null`

No public API changes — both fixes are internal to the native serialization layer.

### Why this shape

- Fixing it in the native layer (vs. pre-serializing on the Ballerina side via `toJsonString()` in `ai.milvus`) means the decimal/JSON guarantees apply to **every** caller of this connector, not just `ai.milvus`. It also keeps Milvus filter expressions like `metadata["fileName"] == "x"` working — those only function when the dynamic column is stored as a real JSON object, which a string-encoded payload would have broken.
- Preferring `int` over `decimal` for whole numbers that fit a `long` matches Ballerina's natural numeric typing on the read side; callers that need a fixed type should use `cloneWithType` against a typed schema.

## Tests

Added in `ballerina/tests/test.bal` under the `json-metadata` group, with an isolated collection so they don't interact with the existing flow:

- `testCreateJsonMetadataCollection` — sets up the collection.
- `testUpsertJsonMetadataWithDecimal` — upserts a row whose dynamic `metadata` carries a decimal, an int, a float, a boolean, a string, a json array, and a nested json object.
- `testQueryJsonMetadataPreservesTypes` — asserts each value comes back with the correct Ballerina type (the regression assertions: fractional `decimal` round-trips as `decimal`, nested object stays a `map<anydata>`, json array stays an array — none of them collapse to a string or to a `DecimalValue` blob).
- `testFilterOnJsonMetadataField` — runs a `metadata["fileName"] == "..."` filter against Milvus to guard against any future regression that pushes metadata back through `toJsonString()` on the Ballerina side; the filter only matches when the value is stored as a real JSON object.

## Examples

N/A — no public API changes.

## Checklist
- [x] Linked to an issue
- [ ] Updated the changelog
- [x] Added tests
- [ ] Updated the spec
- [ ] Checked native-image compatibility